### PR TITLE
Add White_List Option; Only Display Albums with Required Phrase

### DIFF
--- a/dist/admin/config.php
+++ b/dist/admin/config.php
@@ -3,5 +3,6 @@ $cfg_client_id          = 'your_client_id';
 $cfg_client_secret      = 'your_client_secret';
 $cfg_max_accounts       = 1;
 $cfg_log                = false;
-$albums_filter          = ['sauvegarde', 'backup'];
+$albums_filter          = ['sauvegarde', 'backup']; // Do not display albums with these phrases
+$white_list             = ['Display Me']; //Only display albums with this phrase, phrase will be deleted when displayed
 ?>

--- a/dist/nanogp2.php
+++ b/dist/nanogp2.php
@@ -187,12 +187,22 @@
 				foreach ($received['albums'] as $k => $v) {
 					// filter albums (see configuration)
           
-					global $albums_filter;
+					global $albums_filter, $white_list;
           $value = $v['title'];
 					$filter = false;
           foreach( $albums_filter as $one_filter ) {
             if (stripos($value, $one_filter) !== false) {
               $filter = true;
+            }
+          }
+          // White list
+          foreach( $white_list as $one_whitelist ) {
+            if (stripos($value, $one_whitelist) === false) {
+              $filter = true;
+            }
+            else {
+              // strip white list phrase from title
+              $v['title'] = str_ireplace($one_whitelist,"",$v['title']);
             }
           }
           if( $generate_report ) {


### PR DESCRIPTION
This is a bit safer from a privacy perspective as it requires an affirmative act add a particular phrase to a gallery name in order for it to be returned here.

The whitelist phrase is removed from the metadata title so it will not appear in your nanogallery2.

For example, I use the phrase ' - Gallery' as my whitelist, then any folder I want to display in nanogallery2, I append the whitelist name to the end of the folder name.