### PR TITLE
Fix Error Causing Duplicate Responses When Token Expired

### DIFF
--- a/dist/nanogp2.php
+++ b/dist/nanogp2.php
@@ -110,12 +110,13 @@
 		$r = '';
 		do {
 			// loop until no next page token
+			$initial_r = $r;
 			$r = send_gprequest( $url, 'photo', $r );
 			if( $r === 'token_expired') {
 				// error -> get a new access token
 				get_new_access_token();
 				// send request again, with the new access token
-				$r=send_gprequest( $url, 'photo', '' );
+				$r=send_gprequest( $url, 'photo', $initial_r );
 			}
 		} while( $r != '' );
 

--- a/dist/nanogp2.php
+++ b/dist/nanogp2.php
@@ -80,12 +80,14 @@
 		$r = '';
 		do {
 			// loop until no next page token
+			$initial_r = $r;
 			$r = send_gprequest( $url, 'album', $r );
 			if( $r === 'token_expired') {
 				// error -> get a new access token
 				get_new_access_token();
 				// send request again, with the new access token
-				$r=send_gprequest( $url, 'album', '' );
+				// but repeating the pagetoken from the last request
+				$r=send_gprequest( $url, 'album', $initial_r );
 			}
 		} while( $r != '' );
 


### PR DESCRIPTION
If the access token expired after the first page of a multiple page response had been retreived, the previous code would refresh the access token, but start the request over again from page 1.  This would lead to duplicate data appearing in the response.

It was a rare bug that would require exact timing to occur.

This code stores the page request token, and reuses it after the access token is refreshed to avoid any duplicate data.